### PR TITLE
bug/fixes#326

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ vsteam_wcore1903_ps5_tests_result.xml
 vsteam_wcore1903_ps7_tests_result.xml
 integration/fullRun.ps1
 integration/Start-PSCountdown.ps1
+integrationTest-results.xml

--- a/README.md
+++ b/README.md
@@ -123,5 +123,3 @@ You can [run your unit tests also locally](/tools/docker/RunTestsLocally.md) and
 ## License
 
 This project is [licensed under the MIT License](LICENSE).
-
-triger test

--- a/README.md
+++ b/README.md
@@ -123,3 +123,5 @@ You can [run your unit tests also locally](/tools/docker/RunTestsLocally.md) and
 ## License
 
 This project is [licensed under the MIT License](LICENSE).
+
+triger test

--- a/Source/Private/common.ps1
+++ b/Source/Private/common.ps1
@@ -31,9 +31,9 @@ function _callAPI {
       # call.
       [switch]$UseProjectId,
       # This flag makes sure that even if a default project is set that it is
-      # not used to build the URI for the API call. Not all API require or 
+      # not used to build the URI for the API call. Not all API require or
       # allow the project to be used. Setting a default project would cause
-      # that project name to be used in building the URI that would lead to 
+      # that project name to be used in building the URI that would lead to
       # 404 because the URI would not be correct.
       [Alias('IgnoreDefaultProject')]
       [switch]$NoProject
@@ -63,6 +63,11 @@ function _callAPI {
       $params.Add('Uri', $Url)
       $params.Add('UserAgent', (_getUserAgent))
 
+      #always use utf8 and json as default content type instead of xml
+      if ($false -eq $PSBoundParameters.ContainsKey("ContentType")) {
+         $params.Add('ContentType', 'application/json; charset=utf-8')
+      }
+
       if (_useWindowsAuthenticationOnPremise) {
          $params.Add('UseDefaultCredentials', $true)
          $params.Add('Headers', @{ })
@@ -79,7 +84,7 @@ function _callAPI {
             $params['Headers'].Add($key, $AdditionalHeaders[$key])
          }
       }
-   
+
       # We have to remove any extra parameters not used by Invoke-RestMethod
       $extra = 'NoProject', 'UseProjectId', 'Area', 'Resource', 'SubDomain', 'Id', 'Version', 'JSON', 'ProjectName', 'Team', 'Url', 'QueryString', 'AdditionalHeaders'
       foreach ($e in $extra) { $params.Remove($e) | Out-Null }
@@ -135,7 +140,7 @@ function _testAdministrator {
 }
 
 # When you mock this in tests be sure to add a Parameter Filter that matches
-# the Service that should be used. 
+# the Service that should be used.
 # Mock _getApiVersion { return '1.0-gitUnitTests' } -ParameterFilter { $Service -eq 'Git' }
 # Also test in the Assert-MockCalled that the correct version was used in the URL that was
 # built for the API call.
@@ -233,7 +238,7 @@ function _buildRequestURI {
 
    process {
       _hasAccount
-      
+
       $sb = New-Object System.Text.StringBuilder
 
       $sb.Append($(_addSubDomain -subDomain $subDomain -instance $(_getInstance))) | Out-Null

--- a/Source/Public/Add-VSTeamBuildDefinition.ps1
+++ b/Source/Public/Add-VSTeamBuildDefinition.ps1
@@ -11,6 +11,6 @@ function Add-VSTeamBuildDefinition {
    )
 
    process {
-      return _callAPI -Method Post -ProjectName $ProjectName -Area build -Resource definitions -Version $(_getApiVersion Build) -infile $InFile -ContentType 'application/json'
+      return _callAPI -Method Post -ProjectName $ProjectName -Area build -Resource definitions -Version $(_getApiVersion Build) -infile $InFile
    }
 }

--- a/Source/Public/Update-VSTeamBuildDefinition.ps1
+++ b/Source/Public/Update-VSTeamBuildDefinition.ps1
@@ -23,10 +23,10 @@ function Update-VSTeamBuildDefinition {
          # Call the REST API
 
          if ($InFile) {
-            _callAPI -Method Put -ProjectName $ProjectName -Area build -Resource definitions -Id $Id -Version $(_getApiVersion Build) -InFile $InFile -ContentType 'application/json' | Out-Null
+            _callAPI -Method Put -ProjectName $ProjectName -Area build -Resource definitions -Id $Id -Version $(_getApiVersion Build) -InFile $InFile | Out-Null
          }
          else {
-            _callAPI -Method Put -ProjectName $ProjectName -Area build -Resource definitions -Id $Id -Version $(_getApiVersion Build) -Body $BuildDefinition -ContentType 'application/json' | Out-Null
+            _callAPI -Method Put -ProjectName $ProjectName -Area build -Resource definitions -Id $Id -Version $(_getApiVersion Build) -Body $BuildDefinition | Out-Null
          }
       }
    }

--- a/Source/Public/Update-VSTeamRelease.ps1
+++ b/Source/Public/Update-VSTeamRelease.ps1
@@ -21,7 +21,7 @@ function Update-VSTeamRelease {
       if ($Force -or $pscmdlet.ShouldProcess($Id, "Update Release")) {
          # Call the REST API
          $resp = _callAPI -ProjectName $projectName -SubDomain vsrm -Area release -Resource releases -Id $id  `
-            -Method Put -ContentType 'application/json' -body $body -Version $(_getApiVersion Release)
+            -Method Put -body $body -Version $(_getApiVersion Release)
 
          Write-Output $resp
       }

--- a/Source/Public/Update-VSTeamReleaseDefinition.ps1
+++ b/Source/Public/Update-VSTeamReleaseDefinition.ps1
@@ -19,10 +19,10 @@ function Update-VSTeamReleaseDefinition {
       if ($Force -or $pscmdlet.ShouldProcess('', "Update Release Definition")) {
          # Call the REST API
          if ($InFile) {
-            _callAPI -Method Put -ProjectName $ProjectName -SubDomain vsrm -Area Release -Resource definitions -Version $(_getApiVersion Release) -InFile $InFile -ContentType 'application/json' | Out-Null
+            _callAPI -Method Put -ProjectName $ProjectName -SubDomain vsrm -Area Release -Resource definitions -Version $(_getApiVersion Release) -InFile $InFile | Out-Null
          }
          else {
-            _callAPI -Method Put -ProjectName $ProjectName -SubDomain vsrm -Area Release -Resource definitions -Version $(_getApiVersion Release) -Body $ReleaseDefinition -ContentType 'application/json' | Out-Null
+            _callAPI -Method Put -ProjectName $ProjectName -SubDomain vsrm -Area Release -Resource definitions -Version $(_getApiVersion Release) -Body $ReleaseDefinition | Out-Null
          }
       }
    }

--- a/integration/test/010_projects.Tests.ps1
+++ b/integration/test/010_projects.Tests.ps1
@@ -220,7 +220,7 @@ Describe 'VSTeam Integration Tests' -Tag 'integration' {
 
       # Only run for VSTS
       if ($env:API_VERSION -eq 'VSTS') {
-         It 'Get-VSTeamBuildDefinition by Id should return intended attribute values for 1st release definition' {
+         It 'Get-VSTeamReleaseDefinition by Id should return intended attribute values for 1st release definition' {
             $releaseDefId = (Get-VSTeamReleaseDefinition -ProjectName $newProjectName | Where-Object { $_.Name -eq $($newProjectName + "-CD1") }).Id
             $releaseDefId | Should -Not -Be $null
             $releaseDef = Get-VSTeamReleaseDefinition -ProjectName $newProjectName -Id $releaseDefId
@@ -232,13 +232,13 @@ Describe 'VSTeam Integration Tests' -Tag 'integration' {
             $releaseDef.environments[0].deployPhases[0].workflowTasks[0].inputs.targetType | Should -Be "inline"
          }
 
-         It 'Get-VSTeamBuildDefinition by Id should return 2 phases for 2nd build definition' {
+         It 'Get-VSTeamReleaseDefinition by Id should return 2 phases for 2nd build definition' {
             $releaseDefId = (Get-VSTeamReleaseDefinition -ProjectName $newProjectName | Where-Object { $_.Name -eq $($newProjectName + "-CD2") }).Id
             ((Get-VSTeamReleaseDefinition -ProjectName $newProjectName -Id $releaseDefId).environments[0].deployPhases).Count | Should -Be 2
          }
       }
 
-      It 'Remove-VSTeamBuildDefinition should delete build definition' {
+      It 'Remove-VSTeamReleaseDefinition should delete build definition' {
          Get-VSTeamReleaseDefinition -ProjectName $newProjectName | Remove-VSTeamReleaseDefinition -ProjectName $newProjectName -Force
          Get-VSTeamReleaseDefinition -ProjectName $newProjectName | Should -Be $null
       }

--- a/integration/test/sampleFiles/010_releasedef_1.json
+++ b/integration/test/sampleFiles/010_releasedef_1.json
@@ -1,0 +1,137 @@
+{
+   "source": "undefined",
+   "revision": 1,
+   "description": null,
+   "createdBy": null,
+   "createdOn": "0001-01-01T00:00:00",
+   "modifiedBy": null,
+   "modifiedOn": "0001-01-01T00:00:00",
+   "isDeleted": false,
+   "variables": {},
+   "variableGroups": [],
+   "environments": [
+      {
+         "id": 0,
+         "name": "Environment 1",
+         "variables": {},
+         "variableGroups": [],
+         "preDeployApprovals": {
+            "approvals": [
+               {
+                  "rank": 1,
+                  "isAutomated": true,
+                  "isNotificationOn": false,
+                  "id": 0
+               }
+            ]
+         },
+         "postDeployApprovals": {
+            "approvals": [
+               {
+                  "rank": 1,
+                  "isAutomated": true,
+                  "isNotificationOn": false,
+                  "id": 0
+               }
+            ]
+         },
+         "deployPhases": [
+            {
+               "deploymentInput": {
+                  "parallelExecution": {
+                     "parallelExecutionType": 0
+                  },
+                  "skipArtifactsDownload": false,
+                  "artifactsDownloadInput": {
+                     "downloadInputs": []
+                  },
+                  "queueId": 25,
+                  "demands": [],
+                  "enableAccessToken": false,
+                  "timeoutInMinutes": 0,
+                  "jobCancelTimeoutInMinutes": 1,
+                  "condition": "succeeded()",
+                  "overrideInputs": {}
+               },
+               "rank": 1,
+               "phaseType": 1,
+               "name": "Phase 1",
+               "refName": null,
+               "workflowTasks": [
+                  {
+                     "environment": {},
+                     "taskId": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+                     "version": "2.*",
+                     "name": "PowerShell Script",
+                     "refName": "",
+                     "enabled": true,
+                     "alwaysRun": false,
+                     "continueOnError": false,
+                     "timeoutInMinutes": 0,
+                     "definitionType": "task",
+                     "overrideInputs": {},
+                     "condition": "succeeded()",
+                     "inputs": {
+                        "targetType": "inline",
+                        "filePath": "",
+                        "arguments": "",
+                        "script": "Write-Host \"Hello World\"\n",
+                        "errorActionPreference": "stop",
+                        "failOnStderr": "false",
+                        "ignoreLASTEXITCODE": "false",
+                        "pwsh": "false",
+                        "workingDirectory": ""
+                     }
+                  }
+               ]
+            }
+         ],
+         "environmentOptions": {
+            "emailNotificationType": "OnlyOnFailure",
+            "emailRecipients": "release.environment.owner;release.creator",
+            "skipArtifactsDownload": false,
+            "timeoutInMinutes": 0,
+            "enableAccessToken": false,
+            "publishDeploymentStatus": true,
+            "badgeEnabled": false,
+            "autoLinkWorkItems": false,
+            "pullRequestDeploymentEnabled": false
+         },
+         "demands": [],
+         "conditions": [],
+         "executionPolicy": {
+            "concurrencyCount": 1,
+            "queueDepthCount": 0
+         },
+         "schedules": [],
+         "retentionPolicy": {
+            "daysToKeep": 30,
+            "releasesToKeep": 3,
+            "retainBuild": true
+         },
+         "processParameters": {},
+         "properties": {},
+         "preDeploymentGates": {
+            "id": 0,
+            "gatesOptions": null,
+            "gates": []
+         },
+         "postDeploymentGates": {
+            "id": 0,
+            "gatesOptions": null,
+            "gates": []
+         },
+         "environmentTriggers": []
+      }
+   ],
+   "artifacts": [],
+   "triggers": [],
+   "releaseNameFormat": null,
+   "tags": [],
+   "properties": {},
+   "id": 0,
+   "name": "AzureFunctions_CD - 3",
+   "path": "\\",
+   "projectReference": null,
+   "_links": {}
+}

--- a/integration/test/sampleFiles/010_releasedef_2.json
+++ b/integration/test/sampleFiles/010_releasedef_2.json
@@ -1,0 +1,171 @@
+{
+   "source": "undefined",
+   "revision": 1,
+   "description": null,
+   "createdBy": null,
+   "createdOn": "0001-01-01T00:00:00",
+   "modifiedBy": null,
+   "modifiedOn": "0001-01-01T00:00:00",
+   "isDeleted": false,
+   "variables": {},
+   "variableGroups": [],
+   "environments": [
+      {
+         "id": 0,
+         "name": "Environment 1",
+         "variables": {},
+         "variableGroups": [],
+         "preDeployApprovals": {
+            "approvals": [
+               {
+                  "rank": 1,
+                  "isAutomated": true,
+                  "isNotificationOn": false,
+                  "id": 0
+               }
+            ]
+         },
+         "postDeployApprovals": {
+            "approvals": [
+               {
+                  "rank": 1,
+                  "isAutomated": true,
+                  "isNotificationOn": false,
+                  "id": 0
+               }
+            ]
+         },
+         "deployPhases": [
+            {
+               "deploymentInput": {
+                  "parallelExecution": {
+                     "parallelExecutionType": 0
+                  },
+                  "skipArtifactsDownload": false,
+                  "artifactsDownloadInput": {
+                     "downloadInputs": []
+                  },
+                  "queueId": 25,
+                  "demands": [],
+                  "enableAccessToken": false,
+                  "timeoutInMinutes": 0,
+                  "jobCancelTimeoutInMinutes": 1,
+                  "condition": "succeeded()",
+                  "overrideInputs": {}
+               },
+               "rank": 1,
+               "phaseType": 1,
+               "name": "Phase 1",
+               "refName": null,
+               "workflowTasks": [
+                  {
+                     "environment": {},
+                     "taskId": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+                     "version": "2.*",
+                     "name": "PowerShell Script",
+                     "refName": "",
+                     "enabled": true,
+                     "alwaysRun": false,
+                     "continueOnError": false,
+                     "timeoutInMinutes": 0,
+                     "definitionType": "task",
+                     "overrideInputs": {},
+                     "condition": "succeeded()",
+                     "inputs": {
+                        "targetType": "inline",
+                        "filePath": "",
+                        "arguments": "",
+                        "script": "Write-Host \"Hello World\"\n",
+                        "errorActionPreference": "stop",
+                        "failOnStderr": "false",
+                        "ignoreLASTEXITCODE": "false",
+                        "pwsh": "false",
+                        "workingDirectory": ""
+                     }
+                  }
+               ]
+            },
+            {
+               "deploymentInput": {
+                  "parallelExecution": {
+                     "parallelExecutionType": 0
+                  },
+                  "timeoutInMinutes": 0,
+                  "jobCancelTimeoutInMinutes": 1,
+                  "condition": "succeeded()",
+                  "overrideInputs": {}
+               },
+               "rank": 2,
+               "phaseType": 2,
+               "name": "Phase 2 with special char áà",
+               "refName": null,
+               "workflowTasks": [
+                  {
+                     "environment": {},
+                     "taskId": "28782b92-5e8e-4458-9751-a71cd1492bae",
+                     "version": "1.*",
+                     "name": "Delay by 1 minutes",
+                     "refName": "",
+                     "enabled": true,
+                     "alwaysRun": false,
+                     "continueOnError": false,
+                     "timeoutInMinutes": 0,
+                     "definitionType": "task",
+                     "overrideInputs": {},
+                     "condition": "succeeded()",
+                     "inputs": {
+                        "delayForMinutes": "1"
+                     }
+                  }
+               ]
+            }
+         ],
+         "environmentOptions": {
+            "emailNotificationType": "OnlyOnFailure",
+            "emailRecipients": "release.environment.owner;release.creator",
+            "skipArtifactsDownload": false,
+            "timeoutInMinutes": 0,
+            "enableAccessToken": false,
+            "publishDeploymentStatus": true,
+            "badgeEnabled": false,
+            "autoLinkWorkItems": false,
+            "pullRequestDeploymentEnabled": false
+         },
+         "demands": [],
+         "conditions": [],
+         "executionPolicy": {
+            "concurrencyCount": 1,
+            "queueDepthCount": 0
+         },
+         "schedules": [],
+         "retentionPolicy": {
+            "daysToKeep": 30,
+            "releasesToKeep": 3,
+            "retainBuild": true
+         },
+         "processParameters": {},
+         "properties": {},
+         "preDeploymentGates": {
+            "id": 0,
+            "gatesOptions": null,
+            "gates": []
+         },
+         "postDeploymentGates": {
+            "id": 0,
+            "gatesOptions": null,
+            "gates": []
+         },
+         "environmentTriggers": []
+      }
+   ],
+   "artifacts": [],
+   "triggers": [],
+   "releaseNameFormat": null,
+   "tags": [],
+   "properties": {},
+   "id": 0,
+   "name": "AzureFunctions_CD - 3",
+   "path": "\\",
+   "projectReference": null,
+   "_links": {}
+}

--- a/unit/test/Update-VSTeamReleaseDefinition.Tests.ps1
+++ b/unit/test/Update-VSTeamReleaseDefinition.Tests.ps1
@@ -28,7 +28,6 @@ Describe "VSTeamReleaseDefinition" {
             $Area -eq 'Release' -and
             $Resource -eq 'definitions' -and
             $Version -eq "$(_getApiVersion Release)" -and
-            $ContentType -eq 'application/json' -and
             $InFile -eq 'releaseDef.json'
          }
       }
@@ -42,7 +41,6 @@ Describe "VSTeamReleaseDefinition" {
             $Area -eq 'Release' -and
             $Resource -eq 'definitions' -and
             $Version -eq "$(_getApiVersion Release)" -and
-            $ContentType -eq 'application/json' -and
             $InFile -eq $null -and
             $Body -eq "{}"
          }


### PR DESCRIPTION
Fixes #326

fix the encoding issue for all future cmdlets. Added a default ContentType with JSON and UTF8 encoding if not specified otherwise. Also removed the encoding from the build/release definition functions to have default UTF 8.

Additionally, I added integration tests for handling release definitions with special characters in them.